### PR TITLE
Color Picker & Edit Overlay content

### DIFF
--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -3,5 +3,6 @@
     "settings": "Settings",
     "licenses": "Licenses",
     "language": "Language",
-    "overlayTextColor": "Overlay Text Color"
+    "overlayTextColor": "Overlay Text Color",
+    "overlayBackgroundColor": "Overlay Background Color"
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -2,5 +2,6 @@
     "@@locale": "en",
     "settings": "Settings",
     "licenses": "Licenses",
-    "language": "Language"
+    "language": "Language",
+    "overlayTextColor": "Overlay Text Color"
 }

--- a/lib/l10n/arb/app_ja.arb
+++ b/lib/l10n/arb/app_ja.arb
@@ -3,5 +3,6 @@
     "settings": "設定",
     "licenses": "ライセンス",
     "language": "言語",
-    "overlayTextColor": "合成文字色"
+    "overlayTextColor": "合成文字色",
+    "overlayBackgroundColor": "合成背景色"
 }

--- a/lib/l10n/arb/app_ja.arb
+++ b/lib/l10n/arb/app_ja.arb
@@ -2,5 +2,6 @@
     "@@locale": "ja",
     "settings": "設定",
     "licenses": "ライセンス",
-    "language": "言語"
+    "language": "言語",
+    "overlayTextColor": "合成文字色"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,8 +5,15 @@ import 'package:hotkey_manager/hotkey_manager.dart';
 import 'package:screen_capturer/screen_capturer.dart';
 import 'package:image/image.dart' as img;
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flex_color_picker/flex_color_picker.dart';
 import 'l10n/l10n.dart';
 import 'settings.dart';
+
+extension ColorX on Color {
+  img.ColorRgba8 toRgba8() {
+    return img.ColorRgba8(red, green, blue, alpha);
+  }
+}
 
 extension Uint8ListX on Uint8List {
   /// Adds a text overlay to an image.
@@ -33,6 +40,8 @@ extension Uint8ListX on Uint8List {
     int x = 10,
     int y = 10,
     int textHeight = 30,
+    Color textColor = Colors.black,
+    Color backgroundColor = Colors.white,
   }) {
     img.Image? originalImage = img.decodeImage(this);
     if (originalImage == null) return this;
@@ -46,7 +55,7 @@ extension Uint8ListX on Uint8List {
       y1: y,
       x2: x + maxWidth,
       y2: y + textHeight,
-      color: img.ColorRgba8(0, 0, 0, 128),
+      color: backgroundColor.toRgba8(),
     );
 
     // Draw the timestamp on the image
@@ -56,18 +65,24 @@ extension Uint8ListX on Uint8List {
       x: 10,
       y: 10,
       font: img.arial24,
-      color: img.ColorRgb8(0, 0, 0),
+      color: textColor.toRgba8(),
     );
 
     return Uint8List.fromList(img.encodePng(originalImage));
   }
 }
 
+enum ColorMenuTitle {
+  overlayTextColor,
+}
+
+typedef ColorMenu = ({ColorMenuTitle title, Signal<Color> signal});
+
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   final (prefs, _) = await (SharedPreferences.getInstance(), hotKeyManager.unregisterAll()).wait;
-  settings = signal<Settings>(Settings(prefs), autoDispose: true);
+  settings = signal<Settings>(Settings(prefs));
 
   runApp(const MyApp());
 }
@@ -161,10 +176,14 @@ class _MyHomePageState extends State<MyHomePage> {
               MenuItemButton(
                 child: Text(context.l10n.settings),
                 onPressed: () {
+                  final colorMenus = <ColorMenu>[
+                    (title: ColorMenuTitle.overlayTextColor, signal: settings().textOverlayColor)
+                  ];
                   _showMenuDialog(
                     context: context,
                     children: [
                       ListTile(
+                        contentPadding: const EdgeInsets.all(16.0),
                         leading: const Icon(Icons.language),
                         title: Watch(
                           (context) => Text(context.l10n.language),
@@ -185,6 +204,29 @@ class _MyHomePageState extends State<MyHomePage> {
                           }).toList(),
                         ),
                       ),
+                      const Divider(),
+                      for (var index = 0; index < colorMenus.length; index++)
+                        Watch(
+                          (context) => ListTile(
+                            leading: index == 0
+                                ? const Icon(Icons.color_lens)
+                                : const SizedBox.square(dimension: 40.0),
+                            title: Text(switch (colorMenus[index].title) {
+                              ColorMenuTitle.overlayTextColor => context.l10n.overlayTextColor,
+                            }),
+                            trailing: Watch(
+                              (context) => ColorIndicator(
+                                width: 44,
+                                height: 44,
+                                borderRadius: 22,
+                                color: colorMenus[index].signal.value,
+                                onSelect: () => _showColorPicker(colorMenus[index].signal.value)
+                                    .then((value) => colorMenus[index].signal.value = value),
+                              ),
+                              dependencies: [settings().locale, colorMenus[index].signal],
+                            ),
+                          ),
+                        ),
                     ],
                   );
                 },
@@ -276,11 +318,39 @@ class _MyHomePageState extends State<MyHomePage> {
       )
           .then((value) {
         if (value?.imageBytes != null) {
-          return value!.imageBytes!.addTextToImage(DateTime.now().toLocal().toString());
+          return value!.imageBytes!.addTextToImage(
+            DateTime.now().toLocal().toString(),
+            textColor: settings.value.textOverlayColor.value,
+          );
         }
         return null;
       });
     });
+  }
+
+  Future<Color> _showColorPicker(Color color) {
+    return showColorPickerDialog(
+      context,
+      color,
+      width: 40,
+      height: 40,
+      spacing: 0,
+      runSpacing: 0,
+      borderRadius: 0,
+      wheelDiameter: 165,
+      enableOpacity: true,
+      showColorCode: true,
+      colorCodeHasColor: true,
+      pickersEnabled: <ColorPickerType, bool>{
+        ColorPickerType.wheel: true,
+      },
+      actionButtons: const ColorPickerActionButtons(
+        okButton: false,
+        closeButton: true,
+        dialogActionButtons: true,
+      ),
+      constraints: const BoxConstraints(minHeight: 480, minWidth: 320, maxWidth: 320),
+    );
   }
 
   Future<void> _showMenuDialog({

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -72,11 +72,12 @@ extension Uint8ListX on Uint8List {
   }
 }
 
-enum ColorMenuTitle {
+enum OverlayMenuTile {
   overlayTextColor,
+  overlayBackgroundColor,
 }
 
-typedef ColorMenu = ({ColorMenuTitle title, Signal<Color> signal});
+typedef ColorMenu = ({OverlayMenuTile? overlayTile, Signal<Color> signal});
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -177,7 +178,14 @@ class _MyHomePageState extends State<MyHomePage> {
                 child: Text(context.l10n.settings),
                 onPressed: () {
                   final colorMenus = <ColorMenu>[
-                    (title: ColorMenuTitle.overlayTextColor, signal: settings().textOverlayColor)
+                    (
+                      overlayTile: OverlayMenuTile.overlayTextColor,
+                      signal: settings().textOverlayColor
+                    ),
+                    (
+                      overlayTile: OverlayMenuTile.overlayBackgroundColor,
+                      signal: settings().backgroundOverlayColor
+                    ),
                   ];
                   _showMenuDialog(
                     context: context,
@@ -209,16 +217,16 @@ class _MyHomePageState extends State<MyHomePage> {
                         Watch(
                           (context) => ListTile(
                             leading: index == 0
-                                ? const Icon(Icons.color_lens)
-                                : const SizedBox.square(dimension: 40.0),
-                            title: Text(switch (colorMenus[index].title) {
-                              ColorMenuTitle.overlayTextColor => context.l10n.overlayTextColor,
+                                ? const Icon(Icons.layers)
+                                : const SizedBox.square(dimension: 24.0),
+                            title: Text(switch (colorMenus[index].overlayTile) {
+                              OverlayMenuTile.overlayTextColor => context.l10n.overlayTextColor,
+                              OverlayMenuTile.overlayBackgroundColor =>
+                                context.l10n.overlayBackgroundColor,
+                              _ => throw Exception('Invalid overlay tile'),
                             }),
                             trailing: Watch(
                               (context) => ColorIndicator(
-                                width: 44,
-                                height: 44,
-                                borderRadius: 22,
                                 color: colorMenus[index].signal.value,
                                 onSelect: () => _showColorPicker(colorMenus[index].signal.value)
                                     .then((value) => colorMenus[index].signal.value = value),
@@ -321,6 +329,7 @@ class _MyHomePageState extends State<MyHomePage> {
           return value!.imageBytes!.addTextToImage(
             DateTime.now().toLocal().toString(),
             textColor: settings.value.textOverlayColor.value,
+            backgroundColor: settings.value.backgroundOverlayColor.value,
           );
         }
         return null;

--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -59,6 +59,18 @@ class Settings {
     },
   );
 
+  late Signal<Color> backgroundOverlayColor = _setting(
+    'background_overlay_color',
+    get: (key) => Color(prefs.getInt(key) ?? 0xFFFFFFFF),
+    set: (key, val) {
+      if (val == null) {
+        prefs.remove(key);
+      } else {
+        prefs.setInt(key, val.value);
+      }
+    },
+  );
+
   void dispose() {
     for (final cb in _cleanup) {
       cb();

--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -47,6 +47,18 @@ class Settings {
     },
   );
 
+  late Signal<Color> textOverlayColor = _setting(
+    'text_overlay_color',
+    get: (key) => Color(prefs.getInt(key) ?? 0xFF000000),
+    set: (key, val) {
+      if (val == null) {
+        prefs.remove(key);
+      } else {
+        prefs.setInt(key, val.value);
+      }
+    },
+  );
+
   void dispose() {
     for (final cb in _cleanup) {
       cb();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -193,6 +193,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  flex_color_picker:
+    dependency: "direct main"
+    description:
+      name: flex_color_picker
+      sha256: "5c846437069fb7afdd7ade6bf37e628a71d2ab0787095ddcb1253bf9345d5f3a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
+  flex_seed_scheme:
+    dependency: transitive
+    description:
+      name: flex_seed_scheme
+      sha256: "4cee2f1d07259f77e8b36f4ec5f35499d19e74e17c7dce5b819554914082bc01"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   # utils
   shared_preferences: ^2.2.3
   image: ^4.2.0
+  flex_color_picker: ^3.4.1
 
 dependency_overrides:
   screen_capturer_windows: 0.2.0


### PR DESCRIPTION
This pull request introduces new features for customizing overlay text and background colors, along with the necessary localization updates and code enhancements.

### New Features:
* Added options to customize overlay text color and background color in the settings menu. (`lib/main.dart`, `lib/settings.dart`, `lib/l10n/arb/app_en.arb`, `lib/l10n/arb/app_ja.arb`) [[1]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R8-R17) [[2]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R43-R44) [[3]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L49-R58) [[4]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L59-R86) [[5]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R180-R194) [[6]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R215-R237) [[7]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L279-R364) [[8]](diffhunk://#diff-b04be9359f5b5cd200e85033fa2685eb27d6affca8dc7924d72da86c72fc359dR50-R73) [[9]](diffhunk://#diff-2f84c37200a054253c38b0f2d5bdb95ba58c999b2c4c7bbe3ce4556c80a709d0L5-R7) [[10]](diffhunk://#diff-a525398faeff183916ed3065c8b3f61faaca7434184cd0996f618956ed25fc06L5-R7)

### Code Enhancements:
* Introduced a new extension `ColorX` to convert `Color` to `img.ColorRgba8`. (`lib/main.dart`)
* Added a `ColorMenu` typedef and `OverlayMenuTile` enum to manage overlay color settings in the menu. (`lib/main.dart`)

### Dependencies:
* Added `flex_color_picker` to the project dependencies for color picking functionality. (`pubspec.yaml`)